### PR TITLE
Use component

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,49 +1,35 @@
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
-<div class= "container" id="app">
-  <h1>Vue.js with QiitaAPI</h1>
-
-  <input v-model.lazy="query" placeholder="検索ワードを入れてね">
-  <input v-model.lazy="items" placeholder="何件表示しますか？">
-
-  <section v-if="errored">
-    <p>エラーが発生したよ＞＜</p>
-  </section>
-
-  <section v-else>
-    <div v-if="loading">Loading...</div>
-    <div class="panel panel-info table-responsive">
-      <div class="panel-heading"><b>{{ query }}</b>のQiita記事！</div>
-      <table class="table table-striped">
-        <thead>
-          <tr>
-            <th v-for="key in keys">
-              {{ key }}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="article in articles" :key="articles.id">
-            <td v-for="key in keys">
-              <span v-if="key === 'title'">
-                <a :href="article.url">{{ article[key] }}</a>
-              </span>
-              <span v-else="key === 'title'">
-                  {{ article[key] }}
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <title>Query search | QiitaAPI</title>
+  </head>
+  <body>
+    <div class= "container" id="app">
+      <h1>Vue.js with QiitaAPI</h1>
+    
+      <input v-model.lazy="query" placeholder="検索ワードを入れてね">
+      <input v-model.lazy="items" placeholder="何件表示しますか？">
+    
+      <section v-if="errored">
+        <p>エラーが発生したよ＞＜</p>
+      </section>
+    
+      <section v-else>
+        <query-serarch-content :keys="keys" :loading="loading" :query="query" :articles="articles"><query-serarch-content/>
+      </section>
     </div>
-  </section>
-</div>
 
-<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-<script src="https://unpkg.com/vue-router@3.0.1/dist/vue-router.js"></script>
-<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
-
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-
-<script src="src/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="https://unpkg.com/vue-router@3.0.1/dist/vue-router.js"></script>
+    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    
+    <script src="src/main.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,19 +8,17 @@
     <title>Query search | QiitaAPI</title>
   </head>
   <body>
-    <div class= "container" id="app">
-      <h1>Vue.js with QiitaAPI</h1>
-    
-      <input v-model.lazy="query" placeholder="検索ワードを入れてね">
-      <input v-model.lazy="items" placeholder="何件表示しますか？">
-    
-      <section v-if="errored">
-        <p>エラーが発生したよ＞＜</p>
-      </section>
-    
-      <section v-else>
-        <query-serarch-content :keys="keys" :loading="loading" :query="query" :articles="articles"><query-serarch-content/>
-      </section>
+    <div id="app">
+      <query-search-content 
+        :errored="errored"
+        :keys="keys"
+        :loading="loading"
+        :query="query"
+        @query-input='query = $event'
+        :items="items"
+        @items-input='items = $event'
+        :articles="articles"
+      ></query-search-content>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,37 +1,64 @@
-Vue.component('query-serarch-content', {
+Vue.component('query-search-content', {
+  props: ['errored', 'keys', 'loading', 'query', 'items', 'articles'],
+  template: `
+    <div class="container">
+      <h1>Vue.js with QiitaAPI</h1>
+
+      <input :value="query" @keyup.enter="$emit('query-input', $event.target.value)" placeholder="検索ワードを入れてね">
+      <input :value="items" @keyup.enter="$emit('items-input', $event.target.value)" placeholder="何件表示しますか？">
+
+      <section v-if="errored">
+        <p>エラーが発生したよ＞＜</p>
+      </section>
+
+      <section v-else>
+        <query-search-result :keys="keys" :loading="loading" :query="query" :articles="articles"></query-search-result>
+      </section>
+    </div>
+  `
+})
+
+Vue.component('query-search-result', {
   props: ['keys', 'loading', 'query', 'articles'],
   template: `
     <div>
       <div v-if="loading">Loading...</div>
       <div class="panel panel-info table-responsive">
         <div class="panel-heading"><b> {{ query }} </b>のQiita記事！</div>
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th v-for="key in keys">
-                {{ key }}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="article in articles" :key="articles.id">
-              <td v-for="key in keys">
-                <span v-if="key === 'title'">
-                  <a :href="article.url">{{ article[key] }}</a>
-                </span>
-                <span v-else="key === 'title'">
-                    {{ article[key] }}
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <content-table :keys="keys" :articles="articles"></content-table>
       </div>
     </div>
   `
 })
 
-new Vue({
+Vue.component('content-table', {
+  props: ['keys', 'articles'],
+  template: `
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th v-for="key in keys">
+            {{ key }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="article in articles" :key="articles.id">
+          <td v-for="key in keys">
+            <span v-if="key === 'title'">
+              <a :href="article.url">{{ article[key] }}</a>
+            </span>
+            <span v-else="key === 'title'">
+                {{ article[key] }}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `
+})
+
+var vm = new Vue({
   el: '#app',
   data: function() {
     return {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,37 @@
-var vm = new Vue({
+Vue.component('query-serarch-content', {
+  props: ['keys', 'loading', 'query', 'articles'],
+  template: `
+    <div>
+      <div v-if="loading">Loading...</div>
+      <div class="panel panel-info table-responsive">
+        <div class="panel-heading"><b> {{ query }} </b>のQiita記事！</div>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th v-for="key in keys">
+                {{ key }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="article in articles" :key="articles.id">
+              <td v-for="key in keys">
+                <span v-if="key === 'title'">
+                  <a :href="article.url">{{ article[key] }}</a>
+                </span>
+                <span v-else="key === 'title'">
+                    {{ article[key] }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  `
+})
+
+new Vue({
   el: '#app',
   data: function() {
     return {


### PR DESCRIPTION
#3 

# ハマったところ

## コンポーネント化した要素をv-modelで双方向バインディングする
#### 参考
* https://jp.vuejs.org/v2/guide/components.html#%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88%E3%81%A7-v-model-%E3%82%92%E4%BD%BF%E3%81%86
* https://stackoverflow.com/questions/49315487/vuejs-error-avoid-mutating-a-prop-directly?rq=1
* https://qiita.com/clomie/items/7a69ee850a304595142e#value%E3%81%A8input%E3%81%AB%E3%82%88%E3%82%8B%E5%AE%9F%E8%A3%85

#### 解決方法
大前提として、propsした値をそのまま変更してはいけないので`$emit`しましょう。コンポーネントで直接`v-model`してはダメです。

-----

`v-model="hoge"`は実際は以下のシンタックスシュガー
```
<input
  v-bind:value="hoge"
  v-on:input="hoge = $event.target.value"
>
```
なので、
1. コンポーネントのpropsに渡す値が"value"になっている（つまり入力値以外では使わない）
2. inputという名前で一意に識別できる（つまり2つ以上モデルを保有していない）

ならばOK。しかし今回は両方とも満たしていない！
なので以下のようにする。

```
      <query-search-content 
        :query="query"
        @query-input='query = $event'
        :items="items"
        @items-input='items = $event'
```

```
      <input :value="query" @keyup.enter="$emit('query-input', $event.target.value)" placeholder="検索ワードを入れてね">
      <input :value="items" @keyup.enter="$emit('items-input', $event.target.value)" placeholder="何件表示しますか？">
```
ちなみに$emitの第一引数はイベント名で、第二引数は何を親コンポーネントに渡すのか、だと推測できる